### PR TITLE
Wrap fastscapelib_fortran context

### DIFF
--- a/fastscape/processes/boundary.py
+++ b/fastscape/processes/boundary.py
@@ -39,4 +39,4 @@ class BorderBoundary:
         # different border order
         self.ibc = sum(arr_bc * np.array([1, 100, 10, 1000]))
 
-        self.fs_context.ibc = self.ibc
+        self.fs_context["ibc"] = self.ibc

--- a/fastscape/processes/hillslope.py
+++ b/fastscape/processes/hillslope.py
@@ -27,18 +27,18 @@ class LinearDiffusion:
 
     def run_step(self):
         kd = np.broadcast_to(self.diffusivity, self.shape).flatten()
-        self.fs_context.kd = kd
+        self.fs_context["kd"] = kd
 
         # we don't use the kdsed fastscapelib-fortran feature directly
         # see class DifferentialLinearDiffusion
-        self.fs_context.kdsed = -1.
+        self.fs_context["kdsed"] = -1.
 
         # bypass fastscapelib-fortran global state
-        self.fs_context.h = self.elevation.flatten()
+        self.fs_context["h"] = self.elevation.flatten()
 
         fs.diffusion()
 
-        erosion_flat = self.elevation.ravel() - self.fs_context.h
+        erosion_flat = self.elevation.ravel() - self.fs_context["h"]
         self.erosion = erosion_flat.reshape(self.shape)
 
 

--- a/fastscape/processes/marine.py
+++ b/fastscape/processes/marine.py
@@ -83,31 +83,31 @@ class MarineSedimentTransport:
 
     def initialize(self):
         # needed so that channel erosion/transport is disabled below sealevel
-        self.fs_context.runmarine = True
+        self.fs_context["runmarine"] = True
 
     def run_step(self):
-        self.fs_context.ratio = self.ss_ratio_land
+        self.fs_context["ratio"] = self.ss_ratio_land
 
-        self.fs_context.poro1 = self.porosity_sand
-        self.fs_context.poro2 = self.porosity_silt
+        self.fs_context["poro1"] = self.porosity_sand
+        self.fs_context["poro2"] = self.porosity_silt
 
-        self.fs_context.zporo1 = self.e_depth_sand
-        self.fs_context.zporo2 = self.e_depth_silt
+        self.fs_context["zporo1"] = self.e_depth_sand
+        self.fs_context["zporo2"] = self.e_depth_silt
 
-        self.fs_context.kdsea1 = self.diffusivity_sand
-        self.fs_context.kdsea2 = self.diffusivity_silt
+        self.fs_context["kdsea1"] = self.diffusivity_sand
+        self.fs_context["kdsea2"] = self.diffusivity_silt
 
-        self.fs_context.layer = self.layer_depth
+        self.fs_context["layer"] = self.layer_depth
 
-        self.fs_context.sealevel = self.sea_level
-        self.fs_context.Sedflux = self.sediment_source.ravel()
+        self.fs_context["sealevel"] = self.sea_level
+        self.fs_context["Sedflux"] = self.sediment_source.ravel()
 
         # bypass fastscapelib-fortran global state
-        self.fs_context.h = self.elevation.flatten()
+        self.fs_context["h"] = self.elevation.flatten()
 
         fs.marine()
 
-        erosion_flat = self.elevation.ravel() - self.fs_context.h
+        erosion_flat = self.elevation.ravel() - self.fs_context["h"]
         self.erosion = erosion_flat.reshape(self.shape)
 
-        self.ss_ratio_sea = self.fs_context.fmix.copy().reshape(self.shape)
+        self.ss_ratio_sea = self.fs_context["fmix"].copy().reshape(self.shape)

--- a/fastscape/processes/tectonics.py
+++ b/fastscape/processes/tectonics.py
@@ -186,17 +186,17 @@ class HorizontalAdvection:
     )
 
     def run_step(self):
-        self.fs_context.vx = np.broadcast_to(self.u, self.shape).flatten()
-        self.fs_context.vy = np.broadcast_to(self.v, self.shape).flatten()
+        self.fs_context["vx"] = np.broadcast_to(self.u, self.shape).flatten()
+        self.fs_context["vy"] = np.broadcast_to(self.v, self.shape).flatten()
 
         # bypass fastscapelib-fortran state
-        self.fs_context.h = self.surface_elevation.flatten()
-        self.fs_context.b = self.bedrock_elevation.flatten()
+        self.fs_context["h"] = self.surface_elevation.flatten()
+        self.fs_context["b"] = self.bedrock_elevation.flatten()
 
         fs.advect()
 
-        h_advected = self.fs_context.h.reshape(self.shape)
+        h_advected = self.fs_context["h"].reshape(self.shape)
         self.surface_veffect = h_advected - self.surface_elevation
 
-        b_advected = self.fs_context.b.reshape(self.shape)
+        b_advected = self.fs_context["b"].reshape(self.shape)
         self.bedrock_veffect = b_advected - self.bedrock_elevation

--- a/fastscape/tests/test_processes_context.py
+++ b/fastscape/tests/test_processes_context.py
@@ -7,16 +7,16 @@ def test_fastscapelib_context():
 
     p.initialize()
 
-    assert p.context.nx == 4
-    assert p.context.ny == 3
-    assert p.context.xl == 30.
-    assert p.context.yl == 10.
-    assert p.context.h.size == 3 * 4
+    assert p.context["nx"] == 4
+    assert p.context["ny"] == 3
+    assert p.context["xl"] == 30.
+    assert p.context["yl"] == 10.
+    assert p.context["h"].size == 3 * 4
 
     p.run_step(10.)
 
-    assert p.context.dt == 10.
+    assert p.context["dt"] == 10.
 
     p.finalize()
 
-    assert p.context.h is None
+    assert p.context["h"] is None


### PR DESCRIPTION
Fortran objects (i.e., ``fastscapelib_fortran.fastscapecontext``) can't be pickled, so access the data (read/write) via a simple wrapper.